### PR TITLE
Allow empty event type

### DIFF
--- a/src/core/node.c
+++ b/src/core/node.c
@@ -2411,8 +2411,7 @@ static inline dom_exception _dom_event_targets_expand(
  *                 false, else it is true.
  * \return DOM_NO_ERR                     on success
  *         DOM_DISPATCH_REQUEST_ERR       If the event is already in dispatch
- *         DOM_UNSPECIFIED_EVENT_TYPE_ERR If the type of the event is Null or
- *                                        empty string.
+ *         DOM_UNSPECIFIED_EVENT_TYPE_ERR If the type of the event is Null.
  *         DOM_NOT_SUPPORTED_ERR          If the event is not created by 
  *                                        Document.createEvent
  *         DOM_INVALID_CHARACTER_ERR      If the type of this event is not a
@@ -2439,7 +2438,7 @@ dom_exception _dom_node_dispatch_event(dom_event_target *et,
 		evt->in_dispatch = true;
 	}
 
-	if (evt->type == NULL || dom_string_byte_length(evt->type) == 0) {
+	if (evt->type == NULL) {
 		return DOM_UNSPECIFIED_EVENT_TYPE_ERR;
 	}
 


### PR DESCRIPTION
> The type attribute must return the value it was initialized to. When
an event is created the attribute must be initialized to the empty string.
https://dom.spec.whatwg.org/#dom-event-type

See also WPT test: https://wpt.live/dom/events/Event-type-empty.html