### PR TITLE
Fix two endlessly recursive calls in node.

### DIFF
--- a/src/core/element.c
+++ b/src/core/element.c
@@ -1467,6 +1467,11 @@ dom_exception _dom_element_lookup_namespace(dom_node_internal *node,
 		return dom_element_get_attribute(node, xmlns, result);
 	}
 
+	if (node->parent == NULL) {
+		*result = NULL;
+		return DOM_NO_ERR;
+	}
+
 	return dom_node_lookup_namespace(node->parent, prefix, result);
 }
 

--- a/src/core/node.c
+++ b/src/core/node.c
@@ -1557,7 +1557,7 @@ dom_exception _dom_node_lookup_prefix(dom_node_internal *node,
 		dom_string *namespace, dom_string **result)
 {
 	if (node->parent != NULL)
-		return dom_node_lookup_prefix(node, namespace, result);
+		return dom_node_lookup_prefix(node->parent, namespace, result);
 	else
 		*result = NULL;
 
@@ -1576,7 +1576,7 @@ dom_exception _dom_node_is_default_namespace(dom_node_internal *node,
 		dom_string *namespace, bool *result)
 {
 	if (node->parent != NULL)
-		return dom_node_is_default_namespace(node, namespace, result);
+		return dom_node_is_default_namespace(node->parent, namespace, result);
 	else
 		*result = false;
 	return DOM_NO_ERR;


### PR DESCRIPTION
Guard against elements with no parents when looking up namespace.