### PR TITLE
Remove Ubuntu 20.04 from build as it's retired

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - ubuntu-20.04
         compiler:
           # The NetSurf build system can't find LLVM AR (it looks for it
           # in /usr/lib instead of /usr/bin:


### PR DESCRIPTION
Causing the build to fail:
https://github.com/lightpanda-io/libdom/actions/runs/14632994146/job/41058613949