### PR TITLE
Initialize an Event's target, current and phase.

### DIFF
--- a/src/events/event.c
+++ b/src/events/event.c
@@ -51,6 +51,9 @@ dom_exception _dom_event_initialise(dom_event *evt)
 	evt->custom = false;
 
 	evt->type = NULL;
+	evt->current = NULL;
+	evt->target = NULL;
+	evt->phase = 0;
 
 	evt->namespace = NULL;
 


### PR DESCRIPTION
Prevent segfaults in cases where the event is used without being dispatched:

```
const e = document.createEvent('Event');
e.target; // should return null, not crash
```