### PR TITLE
input_element use defaults

### DIFF
--- a/src/html/html_input_element.h
+++ b/src/html/html_input_element.h
@@ -23,6 +23,8 @@ struct dom_html_input_element {
 	bool default_value_set; /**< Whether default_value has been set */
 	bool checked; /**< Whether the element has been checked by a click */
 	bool checked_set;
+	dom_string *value; /**< Initial value */
+	bool value_set; /**< Whether value has been set */
 };
 
 /* Create a dom_html_input_element object */


### PR DESCRIPTION
The default values should be used until the actual values has been set
![image](https://github.com/user-attachments/assets/9d8dfae6-8016-4101-bb61-4b73139c86bf)
