### PR TITLE
Support event bubbling across shadowroot.

### DIFF
--- a/include/dom/core/doc_fragment.h
+++ b/include/dom/core/doc_fragment.h
@@ -8,5 +8,7 @@
 #define dom_core_documentfragment_h_
 
 typedef struct dom_document_fragment dom_document_fragment;
+void _dom_document_fragment_get_host(dom_document_fragment *frag, dom_node_internal **host);
+void _dom_document_fragment_set_host(dom_document_fragment *frag, dom_node_internal *host);
 
 #endif

--- a/src/core/doc_fragment.c
+++ b/src/core/doc_fragment.c
@@ -18,9 +18,6 @@
 /**
  * A DOM document fragment
  */
-struct dom_document_fragment {
-	dom_node_internal base;		/**< Base node */
-};
 
 static const struct dom_node_vtable df_vtable = {
 	{
@@ -60,6 +57,7 @@ dom_exception _dom_document_fragment_create(dom_document *doc,
 
 	f->base.base.vtable = &df_vtable;
 	f->base.vtable = &df_protect_vtable;
+	f->host = NULL;
 
 	/* And initialise the node */
 	err = _dom_document_fragment_initialise(&f->base, doc, 
@@ -86,8 +84,23 @@ void _dom_document_fragment_destroy(dom_document_fragment *frag)
 	/* Finalise base class */
 	_dom_document_fragment_finalise(&frag->base);
 
+	if (frag->host != NULL) {
+		dom_node_unref(frag->host);
+	}
 	/* Destroy fragment */
 	free(frag);
+}
+
+void _dom_document_fragment_get_host(dom_document_fragment *frag, dom_node_internal **host) {
+	*host = frag->host;
+}
+
+void _dom_document_fragment_set_host(dom_document_fragment *frag, dom_node_internal *host) {
+	if (frag->host != NULL) {
+		dom_node_unref(frag->host);
+	}
+	dom_node_ref(host);
+	frag->host = host;
 }
 
 /*-----------------------------------------------------------------------*/
@@ -116,6 +129,7 @@ dom_exception _dom_df_copy(dom_node_internal *old, dom_node_internal **copy)
 		return err;
 	}
 
+	new_f->host = NULL;
 	*copy = (dom_node_internal *) new_f;
 
 	return DOM_NO_ERR;

--- a/src/core/doc_fragment.h
+++ b/src/core/doc_fragment.h
@@ -11,6 +11,12 @@
 #include <dom/core/exceptions.h>
 #include <dom/core/doc_fragment.h>
 
+struct dom_document_fragment {
+	dom_node_internal base;		/**< Base node */
+	/* if the document framgment is part of a shadowroot, this is the host element */
+	dom_node_internal *host;
+};
+
 dom_exception _dom_document_fragment_create(dom_document *doc,
 		dom_string *name, dom_string *value,
 		dom_document_fragment **result);


### PR DESCRIPTION
Normally, ShadowRoots are isolated. For example, document.querySelector won't search within a ShadowRoot. This works pretty well in libdom, since it has no concept of a ShadowRoot - we simply never append the ShadowRoot to libdom's DOM representation.

Except, that doesn't work for events, which don't share that same isolation behavior. Clicking a <div> inside a ShadowRoot bubbles all the way up to the Window - like any other event.

To support this, we add an optional host: *Node to DocumentFragements. The host is the parent element of the shadowroot. If we're bubbling an event, and reach a DocumentFragment which has a host, then we continue bubbling up the host.

I think special-casing the event bubbling is safer and easier than trying to put the ShadowRoot into the DOM. Putting the ShadowRoot into the DOM would require special-casing all places which should ignore the ShadowRoot.