### PR TITLE
Improve event timestamp resolution

### DIFF
--- a/include/dom/events/event.h
+++ b/include/dom/events/event.h
@@ -57,9 +57,9 @@ dom_exception _dom_event_get_cancelable(dom_event *evt, bool *cancelable);
 		(dom_event *) (e), (bool *) (c))
 
 dom_exception _dom_event_get_timestamp(dom_event *evt,
-		unsigned int *timestamp);
+		uint64_t *timestamp);
 #define dom_event_get_timestamp(e, t) _dom_event_get_timestamp(\
-		(dom_event *) (e), (unsigned int *) (t))
+		(dom_event *) (e), (uint64_t *) (t))
 
 dom_exception _dom_event_stop_propagation(dom_event *evt);
 #define dom_event_stop_propagation(e) _dom_event_stop_propagation(\

--- a/src/events/event.c
+++ b/src/events/event.c
@@ -213,7 +213,7 @@ dom_exception _dom_event_get_cancelable(dom_event *evt, bool *cancelable)
  * \param timestamp  The returned value
  * \return DOM_NO_ERR.
  */
-dom_exception _dom_event_get_timestamp(dom_event *evt, unsigned int *timestamp)
+dom_exception _dom_event_get_timestamp(dom_event *evt, uint64_t *timestamp)
 {
 	*timestamp = evt->timestamp;
 	return DOM_NO_ERR;
@@ -261,7 +261,12 @@ dom_exception _dom_event_init(dom_event *evt, dom_string *type,
 	evt->cancelable = cancelable;
 	evt->is_initialised = true;
 
-	evt->timestamp = time(NULL);
+	struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+  uint64_t timestamp = (uint64_t)ts.tv_sec * 1000 + (uint64_t)ts.tv_nsec / 1000000;
+  // reduce resolution for protection against fingerprinting (what Firefox does)
+  evt->timestamp = timestamp - timestamp % 2;
+	// evt->timestamp = time(NULL);
 
 	return DOM_NO_ERR;
 }

--- a/src/events/event.h
+++ b/src/events/event.h
@@ -32,7 +32,7 @@ struct dom_event {
 	dom_event_flow_phase phase;		/**< The event phase */
 	bool bubble;	/**< Whether this event is a bubbling event */
 	bool cancelable;	/**< Whether this event is cancelable */
-	unsigned int timestamp;
+	uint64_t timestamp;
 			/**< The timestamp this event is created */
 
 	dom_string *namespace;	/**< The namespace of this event */


### PR DESCRIPTION
Was seconds, is now milliseconds rounded to 2 (what Firefox does by default).

The specification is for 'high precision', but browsers reduce that for fingerprinting.

The existing resolution (second), causes Browser to crash in WPT tests.