### PR TITLE
fix unref call after dom_node_append_child call

### DIFF
--- a/src/core/node.c
+++ b/src/core/node.c
@@ -1535,6 +1535,10 @@ dom_exception _dom_node_set_text_content(dom_node_internal *node,
 		return err;
 
 	err = dom_node_append_child(node, text, (void *) &r);
+	if (err != DOM_NO_ERR) {
+		dom_node_unref(text);
+		return err;
+	}
 
 	/* The node is held alive as a child here, so unref it */
 	dom_node_unref(text);


### PR DESCRIPTION
r musn't be unref in case of error returned by dom_node_append_child b/c it hasn't be referenced.

see _dom_node_clone_node implementation as reference.