### PR TITLE
When namespace is NULL, match attributes by name only

### DIFF
--- a/src/core/element.c
+++ b/src/core/element.c
@@ -204,11 +204,10 @@ static dom_attr_list * _dom_element_attr_list_find_by_name(
 		return NULL;
 
 	do {
-		if (((namespace == NULL && attr->namespace == NULL) ||
-				(namespace != NULL && attr->namespace != NULL &&
-						dom_string_isequal(namespace,
-						attr->namespace))) &&
-				dom_string_isequal(name, attr->name)) {
+		if ((namespace == NULL || (
+				(attr->namespace != NULL && dom_string_isequal(namespace, attr->namespace)))) &&
+				dom_string_isequal(name, attr->name)
+		) {
 			/* Both have NULL namespace or matching namespace,
 			 * and both have same name */
 			return attr;


### PR DESCRIPTION
I believe this is the correct behavior for getAttribute, setAttribute and removeAttribute - they should work on attributes by name only. So I made this change deep, in `_dom_element_attr_list_find_by_name` to cover all cases. It seems safe to do, but there could be a place that relies on strict namespace null matching...