### PR TITLE
Attributes in the XML namespace should have case-sensitive attributes

### DIFF
--- a/src/html/html_element.h
+++ b/src/html/html_element.h
@@ -166,3 +166,4 @@ extern const struct dom_html_element_vtable _dom_html_element_vtable;
 
 #endif
 
+bool _dom_html_element_should_normalize_attribute_name(dom_element *element);


### PR DESCRIPTION
There's probably a better way to detect XML-namespaced elements, but SVG is the one we're currently dealing with, so this is hard-coded to SVG.